### PR TITLE
fix: use digit-level OCR confidence and enhance debug panel

### DIFF
--- a/src/components/DebugPreview.css
+++ b/src/components/DebugPreview.css
@@ -35,3 +35,62 @@
   max-width: 100%;
   image-rendering: pixelated;
 }
+
+/* Detail breakdown */
+.debug-details {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.8rem;
+  font-family: monospace;
+}
+
+.debug-detail-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.debug-detail-label {
+  color: #888;
+  min-width: 70px;
+}
+
+.debug-detail-sep {
+  width: 1px;
+  height: 14px;
+  background: #444;
+  margin: 0 4px;
+}
+
+.debug-token {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  background: #2a2a2a;
+  border-radius: 3px;
+  padding: 1px 5px;
+}
+
+.debug-token-text {
+  color: #ddd;
+}
+
+.debug-token-conf {
+  font-size: 0.7rem;
+}
+
+.debug-detail-value {
+  color: #ddd;
+}
+
+.debug-skip-badge {
+  background: #f44336;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: bold;
+  padding: 1px 6px;
+  border-radius: 3px;
+}

--- a/src/components/DebugPreview.tsx
+++ b/src/components/DebugPreview.tsx
@@ -6,8 +6,15 @@ interface DebugPreviewProps {
   images: OcrDebugImages
 }
 
+function confidenceColor(conf: number): string {
+  if (conf >= 90) return '#4caf50'
+  if (conf >= 70) return '#ff9800'
+  return '#f44336'
+}
+
 export function DebugPreview({ images }: DebugPreviewProps) {
   const { t } = useTranslation()
+  const r = images.ocrResult
   return (
     <div className="debug-preview">
       <h3>{t('debug.title')}</h3>
@@ -21,6 +28,32 @@ export function DebugPreview({ images }: DebugPreviewProps) {
           <img src={images.processed} alt={t('debug.processedAlt')} />
         </div>
       </div>
+
+      {r && (
+        <div className="debug-details">
+          <div className="debug-detail-row">
+            <span className="debug-detail-label">Text</span>
+            <span className="debug-detail-value">{r.text || '(empty)'}</span>
+            {r.skipped && <span className="debug-skip-badge">SKIPPED</span>}
+          </div>
+          <div className="debug-detail-row">
+            <span className="debug-detail-label">Page conf</span>
+            <span style={{ color: confidenceColor(r.pageConfidence) }}>{r.pageConfidence}</span>
+            <span className="debug-detail-sep" />
+            <span className="debug-detail-label">Digit conf</span>
+            <span style={{ color: confidenceColor(r.digitConfidence) }}>{r.digitConfidence}</span>
+          </div>
+          <div className="debug-detail-row">
+            <span className="debug-detail-label">Symbols</span>
+            {r.symbols.map((s, i) => (
+              <span key={i} className="debug-token">
+                <span className="debug-token-text">{s.text}</span>
+                <span className="debug-token-conf" style={{ color: confidenceColor(s.confidence) }}>{s.confidence}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/lib/exp-parser.ts
+++ b/src/lib/exp-parser.ts
@@ -3,7 +3,7 @@ export interface ParsedExp {
   percentage: number
 }
 
-const EXP_REGEX = /(\d+)\s*\[\s*(\d+\.\d+)\s*%\s*\]/
+const EXP_REGEX = /(\d+)\s*\[\s*(\d{1,2}\.\d{1,2})\s*%\s*\]/
 
 export function parseExpText(text: string): ParsedExp | null {
   const match = text.match(EXP_REGEX)

--- a/src/lib/ocr-service.ts
+++ b/src/lib/ocr-service.ts
@@ -4,11 +4,20 @@ import { parseExpText } from './exp-parser.ts'
 import type { ParsedExp } from './exp-parser.ts'
 import { toGrayscale, threshold, upscale, invert } from './image-preprocessing.ts'
 
-const MIN_CONFIDENCE = 40
+const MIN_CONFIDENCE = 93
+
+export interface OcrDebugResult {
+  text: string
+  pageConfidence: number
+  digitConfidence: number
+  symbols: Array<{ text: string; confidence: number }>
+  skipped: boolean
+}
 
 export interface OcrDebugImages {
   raw: string       // data URL of cropped raw frame
   processed: string // data URL after preprocessing (what Tesseract sees)
+  ocrResult?: OcrDebugResult
 }
 
 export class OcrService {
@@ -59,11 +68,38 @@ export class OcrService {
     ctx.putImageData(final_, 0, 0)
     const blob = await this.ocrCanvas.convertToBlob({ type: 'image/png' })
 
-    const { data: { text, confidence } } = await this.worker.recognize(blob)
-    const trimmed = text.trim()
-    console.log(`[OCR] raw="${trimmed}" confidence=${confidence} size=${final_.width}x${final_.height}`)
+    const { data } = await this.worker.recognize(blob, {}, { blocks: true })
+    const trimmed = data.text.trim()
 
-    if (confidence < MIN_CONFIDENCE) {
+    // Use digit symbol-level confidence instead of page-level mean.
+    // Page-level averages ALL words — Tesseract splits "]" as a separate
+    // word with confidence=0, dragging the mean to ~5 even when every
+    // digit symbol is recognized at 98-99 confidence.
+    const words = data.blocks?.flatMap(b =>
+      b.paragraphs.flatMap(p =>
+        p.lines.flatMap(l => l.words)
+      )
+    ) ?? []
+    const symbols = words.flatMap(w => w.symbols)
+    const digitSymbols = symbols.filter(s => /^\d$/.test(s.text))
+    const confidence = digitSymbols.length > 0
+      ? Math.min(...digitSymbols.map(s => s.confidence))
+      : data.confidence
+    const skipped = confidence < MIN_CONFIDENCE
+
+    if (this.lastDebugImages) {
+      this.lastDebugImages.ocrResult = {
+        text: trimmed,
+        pageConfidence: data.confidence,
+        digitConfidence: confidence,
+        symbols: symbols.map(s => ({ text: s.text, confidence: s.confidence })),
+        skipped,
+      }
+    }
+
+    console.log(`[OCR] raw="${trimmed}" pageConf=${data.confidence} digitConf=${confidence} size=${final_.width}x${final_.height}`)
+
+    if (skipped) {
       console.log(`[OCR] low confidence (${confidence}), skipping`)
       return null
     }


### PR DESCRIPTION
## Summary
- Use per-digit symbol confidence (Math.min) instead of Tesseract page-level mean, which was dragged down by `]` being scored at 0
- Raise MIN_CONFIDENCE from 40 to 93 to match the new, more accurate metric
- Show OCR result details (text, page/digit confidence, per-symbol breakdown, skip status) in the debug panel
- Constrain EXP percentage regex to 1-2 digits per segment (`\d{1,2}\.\d{1,2}`)

## Test plan
- [ ] Enable OCR debug panel and verify text, confidence values, and symbol breakdown are displayed
- [ ] Confirm valid readings pass with digit confidence >= 93
- [ ] Confirm readings with low digit confidence are correctly skipped
- [ ] Verify regex rejects malformed percentages (e.g. `123.456%`, `.5%`)