### PR TITLE
fix: lower OCR threshold from 200 to 180

### DIFF
--- a/src/lib/ocr-service.ts
+++ b/src/lib/ocr-service.ts
@@ -41,7 +41,7 @@ export class OcrService {
     // Preprocess: upscale 4x → grayscale → high threshold → invert
     const scaled = upscale(imageData, 4)
     const gray = toGrayscale(scaled)
-    const binary = threshold(gray, 200)
+    const binary = threshold(gray, 180)
     const final_ = invert(binary)
 
     // Generate debug images only when debug panel is visible


### PR DESCRIPTION
## Summary
- Lower binarization threshold from 200 to 180 to preserve character edges during preprocessing
- Threshold 200 causes digit misreads (e.g. 9→8) on certain pixel patterns from live screen capture
- Needs in-game testing to verify improvement

## Test plan
- [ ] Run tracker in-game and monitor for digit misreads around "190" values
- [ ] Compare chart stability before/after

## Screenshot demostrating the issue:
<img width="1147" height="411" alt="螢幕擷取畫面 2026-03-21 135930" src="https://github.com/user-attachments/assets/6f58e32d-1506-4f98-bd78-b6077d5da355" />
