### PR TITLE
fix: remove invalid Tooltip generic args for recharts 3.8.1

### DIFF
--- a/src/components/ExpChart.tsx
+++ b/src/components/ExpChart.tsx
@@ -26,7 +26,7 @@ export function ExpChart({ data }: ExpChartProps) {
           <CartesianGrid strokeDasharray="3 3" stroke="#333" />
           <XAxis dataKey="time" stroke="#666" fontSize={12} />
           <YAxis stroke="#666" fontSize={12} tickFormatter={(v: number) => v.toLocaleString()} />
-          <Tooltip<number, string>
+          <Tooltip
             contentStyle={{ background: '#1a1a2e', border: '1px solid #444', borderRadius: '8px' }}
             labelStyle={{ color: '#888' }}
             formatter={(value) => [value?.toLocaleString() ?? '0', t('chart.tooltipLabel')]}


### PR DESCRIPTION
## Summary
- recharts 3.8.1's `Tooltip` is not generic (`Tooltip(outsideProps: TooltipProps<ValueType, NameType>)`)
- Remove `<number, string>` generic args added in #38, and drop the explicit type annotation — `ValueType` (`number | string | ReadonlyArray<number | string>`) all have `toLocaleString()` so TS infers correctly

## Test plan
- [x] `pnpm run build` passes
- [x] `vitest run` — 24 tests pass