### PR TITLE
Fix tracking session lifecycle and OCR resilience bugs

### DIFF
--- a/src/hooks/useTracker.test.ts
+++ b/src/hooks/useTracker.test.ts
@@ -8,6 +8,7 @@ const { engineState } = vi.hoisted(() => ({
   engineState: {
     callbacks: null as TrackingCallbacks | null,
     instances: [] as Array<{ start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }>,
+    startBehavior: () => Promise.resolve(),
   },
 }))
 
@@ -16,7 +17,7 @@ vi.mock('../lib/tracking-engine.ts', async (importOriginal) => {
   return {
     ...original,
     TrackingEngine: class {
-      start = vi.fn().mockResolvedValue(undefined)
+      start = vi.fn().mockImplementation(() => engineState.startBehavior())
       stop = vi.fn()
       updateCropRegion = vi.fn()
       setDebugEnabled = vi.fn()
@@ -40,6 +41,7 @@ beforeEach(() => {
   vi.useFakeTimers()
   engineState.callbacks = null
   engineState.instances = []
+  engineState.startBehavior = () => Promise.resolve()
 })
 
 afterEach(() => {
@@ -76,5 +78,25 @@ describe('useTracker session lifecycle', () => {
     // Session started at the new reading: duration 0, gained 0 — not 1000s / 300k
     expect(result.current.metrics.sessionDurationMs).toBe(0)
     expect(result.current.metrics.sessionExpGained).toBe(0)
+  })
+
+  it('does not leak an interval or engine when start fails (picker cancelled)', async () => {
+    engineState.startBehavior = () => Promise.reject(new DOMException('Permission denied', 'NotAllowedError'))
+    const { result } = renderHook(() => useTracker(SETTINGS))
+
+    // Must not reject — App calls this without a catch handler
+    await act(async () => {
+      await result.current.startTracking()
+    })
+
+    expect(vi.getTimerCount()).toBe(0) // no metrics interval left behind
+    expect(result.current.getCapture()).toBeNull() // no stale engine
+
+    // Retry after cancelling must work and create exactly one interval
+    engineState.startBehavior = () => Promise.resolve()
+    await act(async () => {
+      await result.current.startTracking()
+    })
+    expect(vi.getTimerCount()).toBe(1)
   })
 })

--- a/src/hooks/useTracker.test.ts
+++ b/src/hooks/useTracker.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useTracker } from './useTracker'
+import type { TrackingCallbacks } from '../lib/tracking-engine'
+import type { ExpReading, Settings } from '../types'
+
+const { engineState } = vi.hoisted(() => ({
+  engineState: {
+    callbacks: null as TrackingCallbacks | null,
+    instances: [] as Array<{ start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }>,
+  },
+}))
+
+vi.mock('../lib/tracking-engine.ts', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../lib/tracking-engine.ts')>()
+  return {
+    ...original,
+    TrackingEngine: class {
+      start = vi.fn().mockResolvedValue(undefined)
+      stop = vi.fn()
+      updateCropRegion = vi.fn()
+      setDebugEnabled = vi.fn()
+      getCapture = vi.fn()
+      isActive = vi.fn()
+      constructor(callbacks: TrackingCallbacks) {
+        engineState.callbacks = callbacks
+        engineState.instances.push(this as never)
+      }
+    },
+  }
+})
+
+const SETTINGS: Settings = { sampleInterval: 1, cropRegion: null }
+
+function reading(timestamp: number, cumulativeExp: number, percentage: number): ExpReading {
+  return { timestamp, cumulativeExp, displayExp: cumulativeExp, percentage }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  engineState.callbacks = null
+  engineState.instances = []
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useTracker session lifecycle', () => {
+  it('clears the metrics interval and resets the session when capture ends externally', async () => {
+    const { result } = renderHook(() => useTracker(SETTINGS))
+
+    await act(async () => {
+      await result.current.startTracking()
+    })
+    expect(vi.getTimerCount()).toBe(1) // metrics interval running
+
+    // A reading arrives, then the user clicks the browser's "Stop sharing"
+    act(() => {
+      engineState.callbacks!.onReading(reading(1_000_000, 500_000, 10))
+      engineState.callbacks!.onEnded()
+    })
+
+    // Interval must be gone — no timer left ticking
+    expect(vi.getTimerCount()).toBe(0)
+
+    // A new session must start fresh, not inherit the old baseline
+    await act(async () => {
+      await result.current.startTracking()
+    })
+    act(() => {
+      engineState.callbacks!.onReading(reading(2_000_000, 800_000, 20))
+      vi.advanceTimersByTime(2000)
+    })
+
+    // Session started at the new reading: duration 0, gained 0 — not 1000s / 300k
+    expect(result.current.metrics.sessionDurationMs).toBe(0)
+    expect(result.current.metrics.sessionExpGained).toBe(0)
+  })
+})

--- a/src/hooks/useTracker.test.ts
+++ b/src/hooks/useTracker.test.ts
@@ -80,6 +80,64 @@ describe('useTracker session lifecycle', () => {
     expect(result.current.metrics.sessionExpGained).toBe(0)
   })
 
+  it('clears visible chart, level-ups, and OCR warnings when a new session starts', async () => {
+    const { result } = renderHook(() => useTracker(SETTINGS))
+
+    await act(async () => {
+      await result.current.startTracking()
+    })
+    act(() => {
+      // Two readings one bucket apart create a chart point; plus a level-up
+      // and OCR failures that must not survive into the next session
+      engineState.callbacks!.onReading(reading(1_000_000, 500_000, 10))
+      engineState.callbacks!.onReading(reading(1_060_000, 560_000, 16))
+      engineState.callbacks!.onLevelUp()
+      engineState.callbacks!.onOcrFailure(3)
+    })
+    expect(result.current.chartData).toHaveLength(1)
+    expect(result.current.levelUps).toBe(1)
+    expect(result.current.ocrFailures).toBe(3)
+
+    // Session ends externally, then a new one starts
+    act(() => {
+      engineState.callbacks!.onEnded()
+    })
+    await act(async () => {
+      await result.current.startTracking()
+    })
+
+    expect(result.current.chartData).toEqual([])
+    expect(result.current.levelUps).toBe(0)
+    expect(result.current.ocrFailures).toBe(0)
+  })
+
+  it('keeps the previous session results visible when a restart attempt fails', async () => {
+    const { result } = renderHook(() => useTracker(SETTINGS))
+
+    await act(async () => {
+      await result.current.startTracking()
+    })
+    act(() => {
+      engineState.callbacks!.onReading(reading(1_000_000, 500_000, 10))
+      engineState.callbacks!.onReading(reading(1_060_000, 560_000, 16))
+      engineState.callbacks!.onLevelUp()
+      result.current.stopTracking()
+    })
+    expect(result.current.chartData).toHaveLength(1)
+    expect(result.current.levelUps).toBe(1)
+
+    // User clicks Start again but cancels the picker — no session began,
+    // so the previous results must remain visible
+    engineState.startBehavior = () => Promise.reject(new DOMException('Permission denied', 'NotAllowedError'))
+    await act(async () => {
+      await result.current.startTracking()
+    })
+
+    expect(result.current.chartData).toHaveLength(1)
+    expect(result.current.levelUps).toBe(1)
+    expect(result.current.metrics.sessionExpGained).toBe(60_000)
+  })
+
   it('does not leak an interval or engine when start fails (picker cancelled)', async () => {
     engineState.startBehavior = () => Promise.reject(new DOMException('Permission denied', 'NotAllowedError'))
     const { result } = renderHook(() => useTracker(SETTINGS))

--- a/src/hooks/useTracker.ts
+++ b/src/hooks/useTracker.ts
@@ -123,6 +123,14 @@ export function useTracker(settings: Settings) {
       return
     }
 
+    // Clear the previous session's visible state only once the new session
+    // actually began — a failed start (e.g. picker cancelled) must leave the
+    // previous results reviewable, same as after Stop.
+    setChartData([])
+    setLevelUps(0)
+    setOcrFailures(0)
+    setMetrics(computeMetrics([]))
+
     // Metrics update on a separate timer (not every reading)
     metricsIntervalRef.current = setInterval(() => {
       if (readingsRef.current.length > 0) {

--- a/src/hooks/useTracker.ts
+++ b/src/hooks/useTracker.ts
@@ -41,6 +41,28 @@ export function useTracker(settings: Settings) {
   const chartPointsRef = useRef<ChartPoint[]>([])
   const bucketStartRef = useRef(0)
 
+  // Single teardown path shared by user Stop, engine "capture ended", and
+  // failed starts — clears the metrics interval and all session state.
+  const endSession = useCallback(() => {
+    if (metricsIntervalRef.current) {
+      clearInterval(metricsIntervalRef.current)
+      metricsIntervalRef.current = null
+    }
+    // Final metrics update before clearing
+    if (readingsRef.current.length > 0) {
+      setMetrics(computeMetrics(readingsRef.current, sessionStartTimeRef.current, sessionStartExpRef.current, sessionStartPercentageRef.current, levelUpsRef.current))
+    }
+    engineRef.current?.stop()
+    engineRef.current = null
+    readingsRef.current = []
+    sessionStartTimeRef.current = 0
+    sessionStartExpRef.current = 0
+    sessionStartPercentageRef.current = 0
+    levelUpsRef.current = 0
+    chartPointsRef.current = []
+    bucketStartRef.current = 0
+  }, [])
+
   const startTracking = useCallback(async () => {
     const engine = new TrackingEngine({
       onReading: (reading) => {
@@ -86,6 +108,7 @@ export function useTracker(settings: Settings) {
         levelUpsRef.current += 1
         setLevelUps(levelUpsRef.current)
       },
+      onEnded: endSession,
     })
     engineRef.current = engine
 
@@ -97,7 +120,7 @@ export function useTracker(settings: Settings) {
     }, METRICS_UPDATE_INTERVAL)
 
     await engine.start(settings.sampleInterval, settings.cropRegion)
-  }, [settings.sampleInterval, settings.cropRegion])
+  }, [settings.sampleInterval, settings.cropRegion, endSession])
 
   // Sync crop region changes to running engine
   useEffect(() => {
@@ -113,25 +136,9 @@ export function useTracker(settings: Settings) {
   }, [debugEnabled])
 
   const stopTracking = useCallback(() => {
-    if (metricsIntervalRef.current) {
-      clearInterval(metricsIntervalRef.current)
-      metricsIntervalRef.current = null
-    }
-    // Final metrics update
-    if (readingsRef.current.length > 0) {
-      setMetrics(computeMetrics(readingsRef.current, sessionStartTimeRef.current, sessionStartExpRef.current, sessionStartPercentageRef.current, levelUpsRef.current))
-    }
-    engineRef.current?.stop()
-    engineRef.current = null
-    readingsRef.current = []
-    sessionStartTimeRef.current = 0
-    sessionStartExpRef.current = 0
-    sessionStartPercentageRef.current = 0
-    levelUpsRef.current = 0
-    chartPointsRef.current = []
-    bucketStartRef.current = 0
+    endSession()
     setStatus('idle')
-  }, [])
+  }, [endSession])
 
   const getCapture = useCallback(() => {
     return engineRef.current?.getCapture() ?? null

--- a/src/hooks/useTracker.ts
+++ b/src/hooks/useTracker.ts
@@ -112,14 +112,23 @@ export function useTracker(settings: Settings) {
     })
     engineRef.current = engine
 
+    try {
+      await engine.start(settings.sampleInterval, settings.cropRegion)
+    } catch (err) {
+      // Engine start failed (e.g. screen picker cancelled). The engine already
+      // reported status 'error'; don't leave a stale engine or reject — App
+      // calls startTracking without a catch handler.
+      console.error('[Tracking] failed to start:', err)
+      engineRef.current = null
+      return
+    }
+
     // Metrics update on a separate timer (not every reading)
     metricsIntervalRef.current = setInterval(() => {
       if (readingsRef.current.length > 0) {
         setMetrics(computeMetrics(readingsRef.current, sessionStartTimeRef.current, sessionStartExpRef.current, sessionStartPercentageRef.current, levelUpsRef.current))
       }
     }, METRICS_UPDATE_INTERVAL)
-
-    await engine.start(settings.sampleInterval, settings.cropRegion)
   }, [settings.sampleInterval, settings.cropRegion, endSession])
 
   // Sync crop region changes to running engine

--- a/src/i18n/locales.test.ts
+++ b/src/i18n/locales.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import en from './locales/en.json'
+import zhTW from './locales/zh-TW.json'
+import zhCN from './locales/zh-CN.json'
+
+// Must cover every TrackingStatus value — App renders t(`app.status.${status}`)
+const STATUSES = ['idle', 'initializing', 'tracking', 'error'] as const
+
+describe.each([
+  ['en', en],
+  ['zh-TW', zhTW],
+  ['zh-CN', zhCN],
+])('%s locale', (_name, locale) => {
+  it.each(STATUSES)('translates app.status.%s', (status) => {
+    expect((locale as Record<string, string>)[`app.status.${status}`]).toBeTruthy()
+  })
+})

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -3,6 +3,7 @@
   "app.status.idle": "idle",
   "app.status.tracking": "tracking",
   "app.status.initializing": "initializing",
+  "app.status.error": "error",
   "app.stop": "Stop",
   "app.startTracking": "Start Tracking",
   "app.settings": "Settings",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -3,6 +3,7 @@
   "app.status.idle": "空闲",
   "app.status.tracking": "追踪中",
   "app.status.initializing": "初始化中",
+  "app.status.error": "错误",
   "app.stop": "停止",
   "app.startTracking": "开始追踪",
   "app.settings": "设置",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -3,6 +3,7 @@
   "app.status.idle": "閒置",
   "app.status.tracking": "追蹤中",
   "app.status.initializing": "初始化中",
+  "app.status.error": "錯誤",
   "app.stop": "停止",
   "app.startTracking": "開始追蹤",
   "app.settings": "設定",

--- a/src/lib/tracking-engine.test.ts
+++ b/src/lib/tracking-engine.test.ts
@@ -74,6 +74,17 @@ describe('TrackingEngine sample loop', () => {
     engine.stop()
   })
 
+  it('cleans up the OCR worker when capture fails to start', async () => {
+    mockCapture.start.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'))
+
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+
+    await expect(engine.start(1, null)).rejects.toThrow()
+    expect(mockOcr.terminate).toHaveBeenCalled()
+    expect(callbacks.onStatusChange).toHaveBeenLastCalledWith('error')
+  })
+
   it('notifies onEnded when the capture stream ends externally', async () => {
     const callbacks = makeCallbacks()
     const engine = new TrackingEngine(callbacks)

--- a/src/lib/tracking-engine.test.ts
+++ b/src/lib/tracking-engine.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { TrackingEngine } from './tracking-engine'
+import type { TrackingCallbacks } from './tracking-engine'
+
+const { mockCapture, mockOcr } = vi.hoisted(() => ({
+  mockCapture: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    onEnded: vi.fn(),
+    captureFrame: vi.fn(),
+    isActive: vi.fn(),
+  },
+  mockOcr: {
+    initialize: vi.fn(),
+    recognizeExp: vi.fn(),
+    terminate: vi.fn(),
+    lastDebugImages: null as unknown,
+    debugEnabled: false,
+  },
+}))
+
+vi.mock('./screen-capture.ts', () => ({
+  ScreenCapture: class { constructor() { return mockCapture } },
+}))
+
+vi.mock('./ocr-service.ts', () => ({
+  OcrService: class { constructor() { return mockOcr } },
+}))
+
+function makeCallbacks(): TrackingCallbacks {
+  return {
+    onReading: vi.fn(),
+    onStatusChange: vi.fn(),
+    onOcrFailure: vi.fn(),
+    onDebugImages: vi.fn(),
+    onLevelUp: vi.fn(),
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.clearAllMocks()
+  mockCapture.start.mockResolvedValue(undefined)
+  mockCapture.captureFrame.mockReturnValue({} as ImageData)
+  mockCapture.isActive.mockReturnValue(true)
+  mockOcr.initialize.mockResolvedValue(undefined)
+  mockOcr.terminate.mockResolvedValue(undefined)
+  mockOcr.recognizeExp.mockResolvedValue({ rawExp: 1000, percentage: 10 })
+  mockOcr.lastDebugImages = null
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('TrackingEngine sample loop', () => {
+  it('keeps sampling when a sample throws, counting it as an OCR failure', async () => {
+    mockOcr.recognizeExp
+      .mockRejectedValueOnce(new Error('worker terminated mid-recognize'))
+      .mockResolvedValue({ rawExp: 1000, percentage: 10 })
+
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+    await engine.start(1, null)
+
+    // First sample rejects
+    await vi.advanceTimersByTimeAsync(0)
+    expect(callbacks.onOcrFailure).toHaveBeenCalledWith(1)
+
+    // Loop must stay alive: next scheduled sample succeeds
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(callbacks.onReading).toHaveBeenCalledTimes(1)
+
+    engine.stop()
+  })
+})

--- a/src/lib/tracking-engine.test.ts
+++ b/src/lib/tracking-engine.test.ts
@@ -85,6 +85,59 @@ describe('TrackingEngine sample loop', () => {
     expect(callbacks.onStatusChange).toHaveBeenLastCalledWith('error')
   })
 
+  it('re-baselines as a level-up after consecutive rejections when EXP and percentage both dropped', async () => {
+    // Level-up happened while OCR was blocked: last accepted reading was 40%,
+    // readings resume at ~3% of the next level. The naive level-up condition
+    // (pct < last - 50) is unsatisfiable, and the outlier filter rejects
+    // every reading — tracking must recover instead of freezing forever.
+    const seq = [
+      { rawExp: 400_000, percentage: 40 },  // accepted baseline
+      { rawExp: 30_000, percentage: 3 },    // rejected (ratio < 0.5)
+      { rawExp: 31_000, percentage: 3.1 },  // rejected
+      { rawExp: 32_000, percentage: 3.2 },  // rejected
+      { rawExp: 33_000, percentage: 3.3 },  // must re-baseline as level-up
+    ]
+    let call = 0
+    mockOcr.recognizeExp.mockImplementation(() => Promise.resolve(seq[Math.min(call++, seq.length - 1)]))
+
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+    await engine.start(1, null)
+    await vi.advanceTimersByTimeAsync(4100)
+
+    expect(callbacks.onLevelUp).toHaveBeenCalledTimes(1)
+    const readings = callbacks.onReading.mock.calls.map(c => c[0] as { cumulativeExp: number })
+    // Cumulative EXP continues across the level: 400k (old level) + 33k (new)
+    expect(readings.at(-1)?.cumulativeExp).toBe(433_000)
+
+    engine.stop()
+  })
+
+  it('re-baselines without a level-up after consecutive rejections when EXP jumped up', async () => {
+    // A legit >2x EXP jump (e.g. big quest turn-in) trips the outlier filter
+    // on every subsequent reading; tracking must resync, not freeze.
+    const seq = [
+      { rawExp: 200_000, percentage: 20 },   // accepted baseline
+      { rawExp: 500_000, percentage: 50 },   // rejected (ratio > 2)
+      { rawExp: 501_000, percentage: 50.1 }, // rejected
+      { rawExp: 502_000, percentage: 50.2 }, // rejected
+      { rawExp: 503_000, percentage: 50.3 }, // must re-baseline, no level-up
+    ]
+    let call = 0
+    mockOcr.recognizeExp.mockImplementation(() => Promise.resolve(seq[Math.min(call++, seq.length - 1)]))
+
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+    await engine.start(1, null)
+    await vi.advanceTimersByTimeAsync(4100)
+
+    expect(callbacks.onLevelUp).not.toHaveBeenCalled()
+    const readings = callbacks.onReading.mock.calls.map(c => c[0] as { cumulativeExp: number })
+    expect(readings.at(-1)?.cumulativeExp).toBe(503_000)
+
+    engine.stop()
+  })
+
   it('notifies onEnded when the capture stream ends externally', async () => {
     const callbacks = makeCallbacks()
     const engine = new TrackingEngine(callbacks)

--- a/src/lib/tracking-engine.test.ts
+++ b/src/lib/tracking-engine.test.ts
@@ -138,6 +138,23 @@ describe('TrackingEngine sample loop', () => {
     engine.stop()
   })
 
+  it('drops a sample still in flight when the engine stops', async () => {
+    let resolveOcr: (v: { rawExp: number; percentage: number }) => void = () => {}
+    mockOcr.recognizeExp.mockImplementation(() => new Promise((r) => { resolveOcr = r }))
+
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+    await engine.start(1, null)
+    await vi.advanceTimersByTimeAsync(0) // first sample is now awaiting OCR
+
+    engine.stop()
+    resolveOcr({ rawExp: 1000, percentage: 10 })
+    await vi.advanceTimersByTimeAsync(0)
+
+    // The late result must not leak into callbacks after stop
+    expect(callbacks.onReading).not.toHaveBeenCalled()
+  })
+
   it('notifies onEnded when the capture stream ends externally', async () => {
     const callbacks = makeCallbacks()
     const engine = new TrackingEngine(callbacks)

--- a/src/lib/tracking-engine.test.ts
+++ b/src/lib/tracking-engine.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { TrackingEngine } from './tracking-engine'
-import type { TrackingCallbacks } from './tracking-engine'
 
 const { mockCapture, mockOcr } = vi.hoisted(() => ({
   mockCapture: {
@@ -27,13 +26,14 @@ vi.mock('./ocr-service.ts', () => ({
   OcrService: class { constructor() { return mockOcr } },
 }))
 
-function makeCallbacks(): TrackingCallbacks {
+function makeCallbacks() {
   return {
     onReading: vi.fn(),
     onStatusChange: vi.fn(),
     onOcrFailure: vi.fn(),
     onDebugImages: vi.fn(),
     onLevelUp: vi.fn(),
+    onEnded: vi.fn(),
   }
 }
 
@@ -72,5 +72,18 @@ describe('TrackingEngine sample loop', () => {
     expect(callbacks.onReading).toHaveBeenCalledTimes(1)
 
     engine.stop()
+  })
+
+  it('notifies onEnded when the capture stream ends externally', async () => {
+    const callbacks = makeCallbacks()
+    const engine = new TrackingEngine(callbacks)
+    await engine.start(1, null)
+
+    // Simulate the user clicking the browser's own "Stop sharing" button
+    const trackEnded = mockCapture.onEnded.mock.calls[0][0] as () => void
+    trackEnded()
+
+    expect(callbacks.onEnded).toHaveBeenCalled()
+    expect(callbacks.onStatusChange).toHaveBeenLastCalledWith('idle')
   })
 })

--- a/src/lib/tracking-engine.ts
+++ b/src/lib/tracking-engine.ts
@@ -71,7 +71,15 @@ export class TrackingEngine {
   private async sampleLoop(): Promise<void> {
     if (!this.running) return
     const start = Date.now()
-    await this.takeSample()
+    try {
+      await this.takeSample()
+    } catch (err) {
+      // A single failed sample (e.g. transient worker error) must not kill
+      // the loop — count it like an OCR misread and keep sampling.
+      console.error('[Tracking] sample failed:', err)
+      this.consecutiveFailures++
+      this.callbacks.onOcrFailure(this.consecutiveFailures)
+    }
     if (!this.running) return
     // Schedule next sample: interval minus time spent, minimum 0
     const elapsed = Date.now() - start

--- a/src/lib/tracking-engine.ts
+++ b/src/lib/tracking-engine.ts
@@ -19,6 +19,13 @@ export interface TrackingCallbacks {
 // Covers rounding from 2-decimal display precision (0.01%) with margin.
 const PCT_TOLERANCE = 0.1
 
+// After this many consecutive validation rejections the baseline itself is
+// considered stale (e.g. a level-up happened while OCR was blocked) and the
+// next reading is trusted as the new baseline. Rejections are well-parsed,
+// high-confidence readings — several in a row contradicting the baseline
+// means the baseline is wrong, not the readings.
+const REBASELINE_AFTER_REJECTIONS = 3
+
 export class TrackingEngine {
   private capture = new ScreenCapture()
   private ocr = new OcrService()
@@ -26,6 +33,7 @@ export class TrackingEngine {
   private intervalMs = 1000
   private running = false
   private consecutiveFailures = 0
+  private consecutiveRejections = 0
   private lastPercentage: number | null = null
   private lastCumulativeExp: number | null = null
   private lastRawExp: number | null = null
@@ -109,12 +117,18 @@ export class TrackingEngine {
       return
     }
 
+    const rebaseline = this.consecutiveRejections >= REBASELINE_AFTER_REJECTIONS
+
     // Level-up detection: require BOTH percentage and EXP to drop significantly
-    // to avoid false triggers from OCR misreads
+    // to avoid false triggers from OCR misreads. When re-baselining, any drop
+    // in both values means the missed transition was a level-up.
     const lastExpBeforeOffset = this.lastCumulativeExp !== null ? this.lastCumulativeExp - this.expOffset : null
-    const isLevelUp = this.lastPercentage !== null
+    const isLevelUp = (this.lastPercentage !== null
       && parsed.percentage < this.lastPercentage - 50
-      && lastExpBeforeOffset !== null && parsed.rawExp < lastExpBeforeOffset * 0.5
+      && lastExpBeforeOffset !== null && parsed.rawExp < lastExpBeforeOffset * 0.5)
+      || (rebaseline
+        && this.lastPercentage !== null && parsed.percentage < this.lastPercentage
+        && lastExpBeforeOffset !== null && parsed.rawExp < lastExpBeforeOffset)
     if (isLevelUp) {
       // EXP resets per-level. Set offset to last cumulative value directly
       // — not +=, which would double-count.
@@ -127,13 +141,18 @@ export class TrackingEngine {
 
     const adjustedExp = parsed.rawExp + this.expOffset
 
-    if (!isLevelUp) {
+    if (rebaseline && !isLevelUp) {
+      console.log(`[OCR] re-baseline after ${this.consecutiveRejections} rejections: ${adjustedExp} @ ${parsed.percentage}%`)
+    }
+
+    if (!isLevelUp && !rebaseline) {
       // Extreme outlier filter: only when cumulative EXP is large enough for
       // ratio to be meaningful. Below 100k, single mob kills can cause huge ratios.
       if (this.lastCumulativeExp !== null && this.lastCumulativeExp > 100_000 && adjustedExp > 0) {
         const ratio = adjustedExp / this.lastCumulativeExp
         if (ratio > 2 || ratio < 0.5) {
           console.log(`[OCR] outlier filtered: ${adjustedExp} vs prev ${this.lastCumulativeExp} (ratio ${ratio.toFixed(2)})`)
+          this.consecutiveRejections++
           this.consecutiveFailures++
           this.callbacks.onOcrFailure(this.consecutiveFailures)
           return
@@ -149,6 +168,7 @@ export class TrackingEngine {
         const diff = Math.abs(expectedPct - parsed.percentage)
         if (diff > PCT_TOLERANCE) {
           console.log(`[OCR] cross-check failed: expected ${expectedPct.toFixed(2)}% but got ${parsed.percentage}% (diff ${diff.toFixed(2)}%)`)
+          this.consecutiveRejections++
           this.consecutiveFailures++
           this.callbacks.onOcrFailure(this.consecutiveFailures)
           return
@@ -157,6 +177,7 @@ export class TrackingEngine {
     }
 
     this.consecutiveFailures = 0
+    this.consecutiveRejections = 0
     this.lastCumulativeExp = adjustedExp
     this.lastRawExp = parsed.rawExp
     this.lastPercentage = parsed.percentage
@@ -187,6 +208,7 @@ export class TrackingEngine {
     this.capture.stop()
     this.ocr.terminate()
     this.consecutiveFailures = 0
+    this.consecutiveRejections = 0
     this.lastPercentage = null
     this.lastCumulativeExp = null
     this.lastRawExp = null

--- a/src/lib/tracking-engine.ts
+++ b/src/lib/tracking-engine.ts
@@ -11,6 +11,8 @@ export interface TrackingCallbacks {
   onOcrFailure: (consecutiveFailures: number) => void
   onDebugImages: (images: OcrDebugImages) => void
   onLevelUp: () => void
+  /** Fired when the capture stream ends outside our control (browser "Stop sharing"). */
+  onEnded: () => void
 }
 
 // Max allowed discrepancy between expected and actual percentage.
@@ -56,6 +58,7 @@ export class TrackingEngine {
       this.capture.onEnded(() => {
         this.stop()
         this.callbacks.onStatusChange('idle')
+        this.callbacks.onEnded()
       })
 
       this.callbacks.onStatusChange('tracking')

--- a/src/lib/tracking-engine.ts
+++ b/src/lib/tracking-engine.ts
@@ -66,6 +66,9 @@ export class TrackingEngine {
       // Take first reading, then chain next after completion
       this.sampleLoop()
     } catch (err) {
+      // Failed start (e.g. user cancelled the screen picker) must not leak
+      // the already-created OCR worker or leave the engine marked running.
+      this.stop()
       this.callbacks.onStatusChange('error')
       throw err
     }

--- a/src/lib/tracking-engine.ts
+++ b/src/lib/tracking-engine.ts
@@ -107,6 +107,10 @@ export class TrackingEngine {
 
     const parsed = await this.ocr.recognizeExp(frame)
 
+    // stop() may have run while OCR was in flight — a late result must not
+    // reach the callbacks or it would repopulate an already-cleared session.
+    if (!this.running) return
+
     if (this.ocr.lastDebugImages) {
       this.callbacks.onDebugImages(this.ocr.lastDebugImages)
     }


### PR DESCRIPTION
## Summary

Fixes five high-severity bugs in the tracking session lifecycle, one commit per issue:

- **Sampling loop survives thrown samples** — a rejected `takeSample()` (e.g. transient Tesseract worker error) was an unhandled rejection that silently stopped scheduling the next sample, leaving the UI stuck on "tracking" with frozen metrics. Errors are now counted as OCR failures and the loop continues.
- **Browser "Stop sharing" fully resets the session** — ending capture from the browser UI only stopped the engine; the 2s metrics interval kept running forever and session refs were never cleared, so the next session inherited the old start time/EXP baseline. The engine now emits `onEnded` and the hook routes it through the same `endSession()` teardown as user-initiated Stop.
- **Cancelled screen picker no longer leaks** — each cancelled attempt leaked a Tesseract worker and a metrics interval, left a dead engine in `engineRef`, and surfaced as an unhandled promise rejection. The engine now runs full cleanup on failed start, and the hook only creates the interval after start succeeds.
- **Added missing `app.status.error` translation** — the header rendered the raw i18n key when tracking failed to start. Added to en/zh-TW/zh-CN with a test covering every status across all locales.
- **Missed level-ups no longer freeze tracking** — the level-up condition (`pct < last - 50`) is unsatisfiable when the last percentage was below 50, so a level-up missed by OCR caused every subsequent reading to be rejected forever. After 3 consecutive validation rejections the engine now re-baselines: treated as a level-up (EXP offset carried forward) when both EXP and percentage dropped, plain resync otherwise (e.g. >2x quest EXP jumps).

## Testing

- 43 tests pass (up from 24) — new suites for `tracking-engine` and `useTracker`, which previously had no coverage; every fix was developed test-first
- `tsc -b` clean
- Lint shows only the two pre-existing `set-state-in-effect` errors already on main